### PR TITLE
Configure SparkSession with master and app name

### DIFF
--- a/pysparktemplate/src/main.py
+++ b/pysparktemplate/src/main.py
@@ -1,8 +1,8 @@
 from pyspark.sql import SparkSession
 
 spark = SparkSession.builder \
-    .master("local[*]") \
-    .appName("SparkApp") \
+    .master('local[*]') \
+    .appName('SparkApp') \
     .getOrCreate()
 
 df = spark.createDataFrame([[1], [2], [3], [4], [5]])

--- a/pysparktemplate/src/main.py
+++ b/pysparktemplate/src/main.py
@@ -1,6 +1,9 @@
 from pyspark.sql import SparkSession
 
-spark = SparkSession.builder.getOrCreate()
+spark = SparkSession.builder \
+    .master("local[*]") \
+    .appName("SparkApp") \
+    .getOrCreate()
 
 df = spark.createDataFrame([[1], [2], [3], [4], [5]])
 


### PR DESCRIPTION
This pull request updates the Spark session initialization in `pysparktemplate/src/main.py` to explicitly specify the master and application name. This improves clarity and control over the Spark context setup.

* Spark session is now initialized with `.master("local[*]")` and `.appName("SparkApp")`, making the execution environment and application name explicit.