### PR TITLE
Update Python base image to version 3.12

### DIFF
--- a/dockerfiles/Dockerfile.debug
+++ b/dockerfiles/Dockerfile.debug
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/python:3.10 AS base
+FROM mcr.microsoft.com/devcontainers/python:3.12 AS base
 
 # Metadata indicating the maintainer of this Dockerfile
 LABEL MAINTAINER="gvatsal60"


### PR DESCRIPTION
This pull request updates the Python version used in the `dockerfiles/Dockerfile.debug` file to ensure the development environment uses a more recent Python release.

Environment update:

* Changed the base image from Python 3.10 to Python 3.12 in `dockerfiles/Dockerfile.debug` to provide compatibility with newer Python features and dependencies.